### PR TITLE
Restore JComboBox baseline calculation

### DIFF
--- a/demo/combos/forms/ComboDemo.java
+++ b/demo/combos/forms/ComboDemo.java
@@ -1,0 +1,89 @@
+package forms;
+
+import com.bulenkov.darcula.DarculaLaf;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * Combo box demo. Created by sasha on 12/02/16.
+ */
+public class ComboDemo {
+    public static void main(String[] args) throws UnsupportedLookAndFeelException {
+        UIManager.setLookAndFeel(new DarculaLaf());
+        JFrame f = new JFrame("Combo boxes");
+        f.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+        Container contentPane = f.getContentPane();
+
+        JLabel label = new JLabel();
+        JComboBox comboBox = new JComboBox();
+        JTextField textField = new JTextField();
+        JComboBox comboBox2 = new JComboBox();
+        JButton button = new JButton();
+        JComboBox comboBox3 = new JComboBox();
+        JTextArea textArea = new JTextArea();
+        JComboBox comboBox4 = new JComboBox();
+
+        label.setText("label");
+        comboBox.setModel(new DefaultComboBoxModel(new String[]{"Item 1", "Item 2", "Item 3", "Item 4"}));
+        textField.setText("textfield");
+        comboBox2.setModel(new DefaultComboBoxModel(new String[]{"Item 1", "Item 2", "Item 3", "Item 4"}));
+        button.setText("button");
+        comboBox3.setModel(new DefaultComboBoxModel(new String[]{"Item 1", "Item 2", "Item 3", "Item 4"}));
+        textArea.setRows(5);
+        textArea.setColumns(10);
+        textArea.setText("textArea\nother text\nanother text");
+        comboBox4.setModel(new DefaultComboBoxModel(new String[] { "Item 1", "Item 2", "Item 3", "Item 4" }));
+        GroupLayout layout = new GroupLayout(contentPane);
+        contentPane.setLayout(layout);
+        layout.setHorizontalGroup(
+                layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                        .addGroup(layout.createSequentialGroup()
+                                .addContainerGap()
+                                .addGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                                        .addGroup(layout.createSequentialGroup()
+                                                .addComponent(label)
+                                                .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
+                                                .addComponent(comboBox, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE))
+                                        .addGroup(layout.createSequentialGroup()
+                                                .addComponent(textField, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
+                                                .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
+                                                .addComponent(comboBox2, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE))
+                                        .addGroup(layout.createSequentialGroup()
+                                                .addComponent(button)
+                                                .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
+                                                .addComponent(comboBox3, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE))
+                                        .addGroup(layout.createSequentialGroup()
+                                                .addComponent(textArea, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
+                                                .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
+                                                .addComponent(comboBox4, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)))
+                                .addContainerGap(GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+        );
+        layout.setVerticalGroup(
+                layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                        .addGroup(layout.createSequentialGroup()
+                                .addContainerGap()
+                                .addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                        .addComponent(label)
+                                        .addComponent(comboBox, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE))
+                                .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
+                                .addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                        .addComponent(textField, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
+                                        .addComponent(comboBox2, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE))
+                                .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
+                                .addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                        .addComponent(button)
+                                        .addComponent(comboBox3, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE))
+                                .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
+                                .addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                        .addComponent(textArea, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
+                                        .addComponent(comboBox4, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE))
+                                .addContainerGap(GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+        );
+        f.pack();
+        f.setVisible(true);
+        System.out.printf("comboBox baseline %d%n",comboBox.getBaseline(comboBox.getWidth(), comboBox3.getHeight()));
+        System.out.printf("comboBox baseline resize behaviour %s%n", comboBox.getBaselineResizeBehavior());
+    }
+
+}

--- a/demo/demo.iml
+++ b/demo/demo.iml
@@ -5,6 +5,7 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/swingset2" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/swingset3" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/combos" isTestSource="false" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
@@ -13,4 +14,3 @@
     <orderEntry type="module" module-name="Darcula" />
   </component>
 </module>
-

--- a/src/com/bulenkov/darcula/ui/DarculaComboBoxUI.java
+++ b/src/com/bulenkov/darcula/ui/DarculaComboBoxUI.java
@@ -42,11 +42,6 @@ import java.awt.geom.Path2D;
 @SuppressWarnings("GtkPreferredJComboBoxRenderer")
 public class DarculaComboBoxUI extends BasicComboBoxUI implements Border {
   private final JComboBox myComboBox;
-  // Flag for calculating the display size
-  private boolean myDisplaySizeDirty = true;
-
-  // Cached the size that the display needs to render the largest item
-  private Dimension myDisplaySizeCache = new Dimension(0, 0);
   private Insets myPadding;
 
   public DarculaComboBoxUI(JComboBox comboBox) {
@@ -126,65 +121,6 @@ public class DarculaComboBoxUI extends BasicComboBoxUI implements Border {
   @Override
   protected Insets getInsets() {
     return new InsetsUIResource(4, 7, 4, 5);
-  }
-
-  protected Dimension getDisplaySize() {
-    Dimension display = new Dimension();
-
-    ListCellRenderer renderer = comboBox.getRenderer();
-    if (renderer == null) {
-      renderer = new DefaultListCellRenderer();
-    }
-
-    boolean sameBaseline = true;
-
-    Object prototypeValue = comboBox.getPrototypeDisplayValue();
-    if (prototypeValue != null) {
-      display = getSizeForComponent(renderer.getListCellRendererComponent(listBox, prototypeValue, -1, false, false));
-    } else {
-      final ComboBoxModel model = comboBox.getModel();
-
-      int baseline = -1;
-      Dimension d;
-
-      if (model.getSize() > 0) {
-        for (int i = 0; i < model.getSize(); i++) {
-          Object value = model.getElementAt(i);
-          Component rendererComponent = renderer.getListCellRendererComponent(listBox, value, -1, false, false);
-          d = getSizeForComponent(rendererComponent);
-          if (sameBaseline && value != null && (!(value instanceof String) || !"".equals(value))) {
-            int newBaseline = rendererComponent.getBaseline(d.width, d.height);
-            if (newBaseline == -1) {
-              sameBaseline = false;
-            }
-            else if (baseline == -1) {
-              baseline = newBaseline;
-            }
-            else if (baseline != newBaseline) {
-              sameBaseline = false;
-            }
-          }
-          display.width = Math.max(display.width, d.width);
-          display.height = Math.max(display.height, d.height);
-        }
-      }
-      else {
-        display = getDefaultSize();
-        if (comboBox.isEditable()) {
-          display.width = 100;
-        }
-      }
-    }
-
-    if (myPadding != null) {
-      display.width += myPadding.left + myPadding.right;
-      display.height += myPadding.top + myPadding.bottom;
-    }
-
-    myDisplaySizeCache.setSize(display.width, display.height);
-    myDisplaySizeDirty = false;
-
-    return display;
   }
 
   protected Dimension getSizeForComponent(Component comp) {
@@ -400,5 +336,15 @@ public class DarculaComboBoxUI extends BasicComboBoxUI implements Border {
   @Override
   public boolean isBorderOpaque() {
     return false;
+  }
+
+  @Override
+  public Component.BaselineResizeBehavior getBaselineResizeBehavior(JComponent c) {
+    return super.getBaselineResizeBehavior(c);
+  }
+
+  @Override
+  public int getBaseline(JComponent c, int width, int height) {
+    return super.getBaseline(c, width, height);
   }
 }


### PR DESCRIPTION
Overriding and changing the getDisplaySize method in DarculaComboBoxUI has the effect of defeating the combobox display size cache in the superclass and to interfere with the claculations in the getBaseline method.
Removing the overridden getDisplaySize seems to have no negative consequences on the widget painting and layouting and restores the ability of baseline aligning a combo box with other widgets.

Example using javax.swing.GroupLayout and baseline alignment, before:
![combo-before](https://cloud.githubusercontent.com/assets/1875690/13015523/e24d7dbc-d1b9-11e5-9b24-f7da2ca5e07f.png)
After:
![combo-after](https://cloud.githubusercontent.com/assets/1875690/13015524/e625023e-d1b9-11e5-840b-da0e0b37a55b.png)
