### PR TITLE
Fixed color of accelerator used in CheckBoxMenuItem and RadioMenuItem

### DIFF
--- a/src/com/bulenkov/darcula/darcula.properties
+++ b/src/com/bulenkov/darcula/darcula.properties
@@ -158,6 +158,8 @@ Slider.focusInsets=2,2,2,2
 ToggleButtonUI=com.bulenkov.darcula.ui.DarculaToggleButtonUI
 
 MenuItem.acceleratorForeground=eeeeee
+CheckBoxMenuItem.acceleratorForeground=eeeeee
+RadioMenuItem.acceleratorForeground=eeeeee
 PopupMenu.translucentBackground=3c3f41
 
 ToolTip.background=5C5C42


### PR DESCRIPTION
Fixed color of accelerator font used in CheckBoxMenuItems and RadioMenuItems.
Both appeared dark gray when unselected and thus weren't visible.